### PR TITLE
Clarified how we order conversations in API docs

### DIFF
--- a/source/api-blueprint/endpoints/contacts.apib
+++ b/source/api-blueprint/endpoints/contacts.apib
@@ -98,7 +98,7 @@ Deletes a contact.
 
 ### List contact conversations [GET /contacts/{contact_id}/conversations{?q,page_token,limit}]
 
-Lists all the conversations with a contact in reverse chronological order (newest first).
+Lists all the conversations with a contact in reverse chronological order (most recently updated first).
 
 + Parameters
     <!-- include(../includes/query_parameter.apib) -->

--- a/source/api-blueprint/endpoints/conversations.apib
+++ b/source/api-blueprint/endpoints/conversations.apib
@@ -20,7 +20,7 @@ A conversation ID alias follows the pattern <code>alt:ref:{reference}</code>.
 
 ### List conversations [GET /conversations{?q,page_token,limit}]
 
-Lists all the conversations in your company in reverse chronological order (latest updated first).
+Lists all the conversations in your company in reverse chronological order (most recently updated first).
 
 + Parameters
     <!-- include(../includes/query_parameter.apib) -->

--- a/source/api-blueprint/endpoints/teammates.apib
+++ b/source/api-blueprint/endpoints/teammates.apib
@@ -49,7 +49,7 @@ Updates the information of a teammate.
 
 ### List teammate conversations [GET /teammates/{teammate_id}/conversations{?q,page_token,limit}]
 
-Lists the conversations assigned to a teammate in reverse chronological order (newest first).
+Lists the conversations assigned to a teammate in reverse chronological order (most recently updated first).
 
 + Parameters
     + teammate_id (string, required) - Id or email of the teammate

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -433,7 +433,7 @@ curl --include \
   ]
 }
 ```
-Lists the conversations assigned to a teammate in reverse chronological order (newest first).
+Lists the conversations assigned to a teammate in reverse chronological order (most recently updated first).
 
 ### HTTP Request
 
@@ -1335,7 +1335,7 @@ curl --include \
   ]
 }
 ```
-Lists all the conversations in your company in reverse chronological order (latest updated first).
+Lists all the conversations in your company in reverse chronological order (most recently updated first).
 
 ### HTTP Request
 
@@ -3230,7 +3230,7 @@ curl --include \
   ]
 }
 ```
-Lists all the conversations with a contact in reverse chronological order (newest first).
+Lists all the conversations with a contact in reverse chronological order (most recently updated first).
 
 ### HTTP Request
 


### PR DESCRIPTION
## What Changed
* Changed the wording explaining how we order conversations in API responses after receiving this question from a customer: https://app.frontapp.com/open/cnv_nyvps1

Effectively just changed 
> "Lists all the conversations with a contact in reverse chronological order (newest first)."

to

> "Lists all the conversations with a contact in reverse chronological order (most recently updated first)."

