### PR TITLE
Clarify exactly what type of event will trigger updating a Plugin

### DIFF
--- a/source/includes/plugin/_events.md
+++ b/source/includes/plugin/_events.md
@@ -15,7 +15,7 @@ Front.on('panel_visible', function (visible) {
 });
 ```
 
-Every time the current conversation changes, an event is sent to our library.
+Every time the current conversation changes (for example, when you click a new conversation in the list), an event is sent to our library.
 
 The data object sent to the callbacks of the event contains 4 fields:
 
@@ -92,6 +92,6 @@ The data object sent to the callbacks of the event contains 4 fields:
       "filename": "chart.jpg",
       "content_type": "image/jpeg",
       "size": "391970"
-  }] 
+  }]
 }
 ```


### PR DESCRIPTION
## Changed
* Slightly updated the wording in plugin docs to clarify exactly what type of event will trigger an update to a plugin.

<img width="644" alt="screenshot 2018-05-08 14 23 33" src="https://user-images.githubusercontent.com/273718/39783900-772efe08-52cb-11e8-809a-0fded915b6a6.png">
