### PR TITLE
Fixing misleading compare that could be prone to timing attack.

### DIFF
--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -18,7 +18,7 @@ function validateFrontSignature(data, signature) {
                      .update(JSON.stringify(data))
                      .digest('base64');
 
-   return hash === signature;
+   return crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(signature));
 }
 ```
 


### PR DESCRIPTION
Just change a code snippet to make the comparison safe to timing attacks.