### PR TITLE
PB-5937 Oauth Refresh Token Documentation

### DIFF
--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -9,6 +9,8 @@ Front's OAuth implementation only supports the [authorization code grant type](h
 
 An access token will expire an hour after it has been issued. Upon expiration, a new access token can be requested by using the refresh token.
 
+**Effective June 1, 2019 we will enforce `access_token` expiration**
+
 ## 1. Request authorization
 
 ```http
@@ -75,6 +77,8 @@ Your request **MUST** be authentified with [Basic authentication](https://tools.
 Front OAuth server response will include the API token in the `access_token` param.
 
 Please store the `refresh_token` securely, as it is required to obtain a new `access_token`. A refresh token will expire six months after it has been issued. A `refresh_token` is automatically refreshed when it is about to expire, when requesting a new `access_token` in the next step.
+
+**Effective June 1, 2019 we will enforce `access_token` expiration**
 
 ### Parameters
 

--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -5,15 +5,7 @@ OAuth 2.0 is a protocol that lets external applications request authorization to
 Each OAuth application is assigned a unique Client ID and Client Secret which will be used in the authorization flow. The Client Secret should **never** be shared.  
 If you want to create an OAuth application, please contact us on <a href="mailto:api@frontapp.com">api@frontapp.com</a> to get your credentials.
 
-Front's OAuth implementation only supports the [authorization code grant type](https://tools.ietf.org/html/rfc6749#section-4.1) which define a flow to get a temporary authorization token which can then be exchanged to get an API and refresh token.
-
-An access token will expire an hour after it has been issued. Upon expiration, a new access token can be requested by using the refresh token.
-
-When developing your integration, please programmatically account for the case that the `access_token` must be refreshed with the `refresh_token` upon `access_token` expiration. When requesting resources with an expired `access_token`, Front's OAuth server response will return a `401` error status code, denoting that the `access_token` has expired.
-
-**Newly created OAuth Applications will have `access_token` expiration enforced.**
-
-**Additionally, effective June 1, 2019, `access_token` expiration will be enforced for existing OAuth Applications**
+Front's OAuth implementation only supports the [authorization code grant type](https://tools.ietf.org/html/rfc6749#section-4.1) which defines a flow to get a temporary authorization token which can then be exchanged to get an API and refresh token.
 
 ## 1. Request authorization
 
@@ -81,11 +73,7 @@ Your request **MUST** be authenticated with [Basic authentication](https://tools
 
 Front OAuth server response will include two tokens (the API token in the `access_token` param and the refresh token in the `refresh_token` param) and the `access_token` expiration time in the `expires_at` param.
 
-The `access_token` will expire after 1 hour, so please store the `refresh_token` securely, as it is required to obtain a new `access_token`. A refresh token will expire six months after it has been issued. A `refresh_token` is automatically refreshed when it is about to expire, when requesting a new `access_token` in the next step.
-
-**Newly created OAuth Applications will have `access_token` expiration enforced.**
-
-**Additionally, effective June 1, 2019, `access_token` expiration will be enforced for existing OAuth Applications**
+Please store the `refresh_token` securely, as it is required to obtain a new `access_token` in the next step.
 
 ### Parameters
 

--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -11,7 +11,9 @@ An access token will expire an hour after it has been issued. Upon expiration, a
 
 When developing your integration, please programmatically account for the case that the `access_token` must be refreshed with the `refresh_token` upon `access_token` expiration. When requesting resources with an expired `access_token`, Front's OAuth server response will return a `401` error status code, denoting that the `access_token` has expired.
 
-**Newly created OAuth Applications will have `access_token` expiration enforced. Additionally, effective June 1, 2019, we will enforce `access_token` expiration for existing OAuth Applications**
+**Newly created OAuth Applications will have `access_token` expiration enforced.**
+
+**Additionally, effective June 1, 2019, `access_token` expiration will be enforced for existing OAuth Applications**
 
 ## 1. Request authorization
 
@@ -81,7 +83,9 @@ Front OAuth server response will include two tokens (the API token in the `acces
 
 The `access_token` will expire after 1 hour, so please store the `refresh_token` securely, as it is required to obtain a new `access_token`. A refresh token will expire six months after it has been issued. A `refresh_token` is automatically refreshed when it is about to expire, when requesting a new `access_token` in the next step.
 
-**Newly created OAuth Applications will have `access_token` expiration enforced. Additionally, effective June 1, 2019, we will enforce `access_token` expiration for existing OAuth Applications**
+**Newly created OAuth Applications will have `access_token` expiration enforced.**
+
+**Additionally, effective June 1, 2019, `access_token` expiration will be enforced for existing OAuth Applications**
 
 ### Parameters
 

--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -11,7 +11,7 @@ An access token will expire an hour after it has been issued. Upon expiration, a
 
 When developing your integration, please programmatically account for the case that the `access_token` must be refreshed with the `refresh_token` upon `access_token` expiration. When requesting resources with an expired `access_token`, Front's OAuth server response will return a `401` error status code, denoting that the `access_token` has expired.
 
-**Effective June 1, 2019 we will enforce `access_token` expiration**
+**Newly created OAuth Applications will have `access_token` expiration enforced. Additionally, effective June 1, 2019, we will enforce `access_token` expiration for existing OAuth Applications**
 
 ## 1. Request authorization
 
@@ -66,9 +66,10 @@ Authorization: Basic <your_basic_credentials>
 
 ```json
 {
-    "access_token": "",
+    "access_token" : "",
     "refresh_token": "",
-    "token_type": "Bearer"
+    "expires_at"   : "",
+    "token_type"   : "Bearer"
 }
 ```
 
@@ -76,11 +77,11 @@ Once your application receive the temporary authorization code, you need to exch
 
 Your request **MUST** be authenticated with [Basic authentication](https://tools.ietf.org/html/rfc2617#section-2) using your OAuth application Client ID and Client Secret.
 
-Front OAuth server response will include two tokens: the API token in the `access_token` param and the refresh token in the `refresh_token` param.
+Front OAuth server response will include two tokens (the API token in the `access_token` param and the refresh token in the `refresh_token` param) and the `access_token` expiration time in the `expires_at` param.
 
 The `access_token` will expire after 1 hour, so please store the `refresh_token` securely, as it is required to obtain a new `access_token`. A refresh token will expire six months after it has been issued. A `refresh_token` is automatically refreshed when it is about to expire, when requesting a new `access_token` in the next step.
 
-**Effective June 1, 2019 we will enforce `access_token` expiration**
+**Newly created OAuth Applications will have `access_token` expiration enforced. Additionally, effective June 1, 2019, we will enforce `access_token` expiration for existing OAuth Applications**
 
 ### Parameters
 
@@ -102,9 +103,10 @@ Authorization: Basic <your_basic_credentials>
 
 ```json
 {
-    "access_token": "",
+    "access_token" : "",
     "refresh_token": "",
-    "token_type": "Bearer"
+    "expires_at"   : "",
+    "token_type"   : "Bearer"
 }
 ```
 
@@ -112,7 +114,7 @@ When the `access_token` from Step 3 has expired after an hour, it will need be b
 
 To obtain a new `access_token`, send a POST request to `/oauth/token` with the `refresh_token` acquired in Step 3 and `grant_type` set to `refresh_token`.
 
-Front OAuth server response will include two tokens: new API token in the `access_token` param and **the same, or new** `refresh_token` in the `refresh_token` param.
+Front OAuth server response will include two tokens (the new API token in the `access_token` param and **the same, or new** `refresh_token` in the `refresh_token` param) and the `access_token` expiration time in the `expires_at` param.
 
 When a `refresh_token` is about to expire, it will automatically be refreshed by Front's OAuth server. No implemenation is required on your end to receive a new `refresh_token`. 
 

--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -102,7 +102,9 @@ Authorization: Basic <your_basic_credentials>
 }
 ```
 
-When the `access_token` from Step 3 has expired after an hour, it will need be be refreshed to continue usage. Similar to Step 3, your request **MUST** be authenticated with [Basic authentication](https://tools.ietf.org/html/rfc2617#section-2) using your OAuth application Client ID and Client Secret. 
+When the `access_token` from Step 3 has expired after an hour, it will need be be refreshed to continue usage. When requesting resources with an expired `access_token`, Front's OAuth server response will return a `401` error status code, denoting that the `access_token` has expired.
+
+Similar to Step 3, your request **MUST** be authenticated with [Basic authentication](https://tools.ietf.org/html/rfc2617#section-2) using your OAuth application Client ID and Client Secret. 
 
 To obtain a new `access_token`, send a POST request to `/oauth/token` with the `refresh_token` acquired in Step 3 and `grant_type` set to `refresh_token`.
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
## Description
This PR updates the documentation to include refresh tokens and how to use them. It instructs users to account for the case that access tokens expire and how they should use the refresh token generated to get a new access token.

## Note
I wrote that expiring `access_tokens` will be enforced June 1, 2019 - please let me know if we want to change that timeline 

## Screenshots
For easier reading:

<img width="1709" alt="screen shot 2018-11-26 at 10 30 05 am" src="https://user-images.githubusercontent.com/7429760/49024118-c80c2f00-f166-11e8-8d7c-820503dec448.png">
<img width="1712" alt="screen shot 2018-11-26 at 10 30 14 am" src="https://user-images.githubusercontent.com/7429760/49024124-c93d5c00-f166-11e8-9595-6772b3d91841.png">
<img width="1709" alt="screen shot 2018-11-26 at 10 30 22 am" src="https://user-images.githubusercontent.com/7429760/49024131-cb071f80-f166-11e8-9fc1-99e5c095b6be.png">
