### PR TITLE
De-lists `is_admin` param for PATCH /teammates/:id endpoint

### DIFF
--- a/source/api-blueprint/data_structures/tag.apib
+++ b/source/api-blueprint/data_structures/tag.apib
@@ -18,5 +18,5 @@
 
 ## Tag to update
 + name: `Robots` (string, optional) - Name of the tag to create.
-+ highlight: `blue` (string, optional) - Color to highlight the tag with. . Set to `null` to remove highlighting.
++ highlight: `blue` (string, optional) - Color to highlight the tag with. Set to `null` to remove highlighting.
 

--- a/source/api-blueprint/data_structures/team.apib
+++ b/source/api-blueprint/data_structures/team.apib
@@ -8,5 +8,5 @@
 ## Team details
 
 + Include Team
-+ inboxes (array[Inbox], required) - List of the inboxees in the team
++ inboxes (array[Inbox], required) - List of the inboxes in the team
 + members (array[Teammate], required) - List of the teammates that have access to the team

--- a/source/api-blueprint/data_structures/teammate.apib
+++ b/source/api-blueprint/data_structures/teammate.apib
@@ -19,5 +19,4 @@
 + username: `bender` (string, optional) - New username. It must be unique and can only contains lowercase letters, numbers and underscores.
 + first_name: `Bender` (string, optional) - New first name
 + last_name: `Rodriguez` (string, optional) - New last name
-+ is_admin: `true` (boolean, optional) - New admin status
 + is_available: `false` (boolean, optional) - New availability status


### PR DESCRIPTION
* De-lists `is_admin` param for `PATCH /teammates/:id` endpoint
* Fixes minor typos

Supersedes https://github.com/frontapp/api-documentation/pull/51

See https://github.com/frontapp/front/pull/12408 for context