### PR TITLE
PB-10243 canned answer docs

### DIFF
--- a/source/api-blueprint/apiary.apib
+++ b/source/api-blueprint/apiary.apib
@@ -48,6 +48,9 @@ HOST: https://api2.frontapp.com/
 # Group Exports
 <!-- include(endpoints/exports.apib) -->
 
+# Group Responses
+<!-- include(endpoints/responses.apib) -->
+
 # Data Structures
 <!-- include(data_structures/teammate.apib) -->
 <!-- include(data_structures/inbox.apib) -->
@@ -66,3 +69,4 @@ HOST: https://api2.frontapp.com/
 <!-- include(data_structures/topic.apib) -->
 <!-- include(data_structures/custom_field.apib) -->
 <!-- include(data_structures/team.apib) -->
+<!-- include(data_structures/response.apib) -->

--- a/source/api-blueprint/data_structures/response.apib
+++ b/source/api-blueprint/data_structures/response.apib
@@ -3,3 +3,9 @@
 <!-- include(../includes/links_attribute.apib) -->
     + self: `https://api2.frontapp.com/responses/rsp_42` (string, required) - URL of the response
 + id: `rsp_42` (string, required) - Unique identifier of the response
++ name: `My canned response` (string, required) - Name of the repsonse
++ subject: `Dogs in here` (string, required) - Subject of the repsonse
++ body: `I heard there were dogs in here.` (string, required) - Body of the response
++ attachments (array[Attachment]) - List of files attached to the response
++ created_at (number) - Timestamp of response creation
++ updated_at (number) - Timestamp of the last update

--- a/source/api-blueprint/data_structures/response.apib
+++ b/source/api-blueprint/data_structures/response.apib
@@ -1,0 +1,5 @@
+## Response
+
+<!-- include(../includes/links_attribute.apib) -->
+    + self: `https://api2.frontapp.com/responses/rsp_42` (string, required) - URL of the response
++ id: `rsp_42` (string, required) - Unique identifier of the response

--- a/source/api-blueprint/endpoints/responses.apib
+++ b/source/api-blueprint/endpoints/responses.apib
@@ -1,6 +1,6 @@
 ## Responses [/responses/{response_id}]
 
-A response is predetermined answer to common questions. They allow you to respond faster to inbound messages, and lessen the repetitive nature of replying to frequently asked questions.
+Responses are predetermined answer to common questions. They allow you to respond faster to inbound messages, and lessen the repetitive nature of replying to frequently asked questions.
 
 Front allows individual and team canned responses. Individual canned responses are visible to only you, and team canned responses can be visible to your teammates on a per inbox level.
 
@@ -25,7 +25,7 @@ Lists the responses in your company.
 
 ### Get response [GET]
 
-Fetches the information of a response.
+Fetches the information of an individual response.
 
 + Request
     <!-- include(../includes/request_header.apib) -->

--- a/source/api-blueprint/endpoints/responses.apib
+++ b/source/api-blueprint/endpoints/responses.apib
@@ -1,6 +1,8 @@
 ## Responses [/responses/{response_id}]
 
-A response is .
+A response is predetermined answer to common questions. They allow you to respond faster to inbound messages, and lessen the repetitive nature of replying to frequently asked questions.
+
+Front allows individual and team canned responses. Individual canned responses are visible to only you, and team canned responses can be visible to your teammates on a per inbox level.
 
 + Parameters
     + response_id (string, required) - Id the requested response
@@ -16,6 +18,7 @@ Lists the responses in your company.
 
 + Response 200 (application/json)
     + Attributes
+        <!-- include(../includes/pagination_attribute.apib) -->
         <!-- include(../includes/links_attribute.apib) -->
             + self: `https://api2.frontapp.com/responses` (string, required)
         + _results (array[Response], required) - List of all the responses in your company

--- a/source/api-blueprint/endpoints/responses.apib
+++ b/source/api-blueprint/endpoints/responses.apib
@@ -1,0 +1,31 @@
+## Responses [/responses/{response_id}]
+
+A response is .
+
++ Parameters
+    + response_id (string, required) - Id the requested response
+
++ Attributes (Response)
+
+### List Responses [GET /responses]
+
+Lists the responses in your company.
+
++ Request
+    <!-- include(../includes/request_header.apib) -->
+
++ Response 200 (application/json)
+    + Attributes
+        <!-- include(../includes/links_attribute.apib) -->
+            + self: `https://api2.frontapp.com/responses` (string, required)
+        + _results (array[Response], required) - List of all the responses in your company
+
+### Get response [GET]
+
+Fetches the information of a response.
+
++ Request
+    <!-- include(../includes/request_header.apib) -->
+
++ Response 200 (application/json)
+    + Attributes (Response, required)

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -5428,8 +5428,16 @@ Name | Type | Description
 _links | object | See [Response body Structure - Links](#links) 
 _links.self | string | URL of the response 
 id | string | Unique identifier of the response 
+name | string | Name of the repsonse 
+subject | string | Subject of the repsonse 
+body | string | Body of the response 
+attachments | array (optional) | List of files attached to the response 
+created_at | number (optional) | Timestamp of response creation 
+updated_at | number (optional) | Timestamp of the last update 
 
-A response is .
+A response is predetermined answer to common questions. They allow you to respond faster to inbound messages, and lessen the repetitive nature of replying to frequently asked questions.
+
+Front allows individual and team canned responses. Individual canned responses are visible to only you, and team canned responses can be visible to your teammates on a per inbox level.
 
 ## List Responses
 ```shell
@@ -5448,6 +5456,7 @@ curl --include \
 
 ```json
 {
+  "_pagination": {},
   "_links": {
     "self": "https://api2.frontapp.com/responses"
   },
@@ -5456,7 +5465,24 @@ curl --include \
       "_links": {
         "self": "https://api2.frontapp.com/responses/rsp_42"
       },
-      "id": "rsp_42"
+      "id": "rsp_42",
+      "name": "My canned response",
+      "subject": "Dogs in here",
+      "body": "I heard there were dogs in here.",
+      "attachments": [
+        {
+          "filename": "attachment.jpg",
+          "url": "https://api2.frontapp.com/download/fil_55c8c149",
+          "content_type": "image/jpeg",
+          "size": 10000,
+          "metadata": {
+            "is_inline": true,
+            "cid": "123456789"
+          }
+        }
+      ],
+      "created_at": 0,
+      "updated_at": 0
     }
   ]
 }
@@ -5486,7 +5512,24 @@ curl --include \
   "_links": {
     "self": "https://api2.frontapp.com/responses/rsp_42"
   },
-  "id": "rsp_42"
+  "id": "rsp_42",
+  "name": "My canned response",
+  "subject": "Dogs in here",
+  "body": "I heard there were dogs in here.",
+  "attachments": [
+    {
+      "filename": "attachment.jpg",
+      "url": "https://api2.frontapp.com/download/fil_55c8c149",
+      "content_type": "image/jpeg",
+      "size": 10000,
+      "metadata": {
+        "is_inline": true,
+        "cid": "123456789"
+      }
+    }
+  ],
+  "created_at": 0,
+  "updated_at": 0
 }
 ```
 Fetches the information of a response.

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -5420,3 +5420,83 @@ start | number | Start time of the data to include in the export.
 end | number | End time of the data to include in the export. 
 timezone | string (optional) | Name of the timezone to format the dates. If omitted, the export will use UTC. 
 should_export_events | boolean (optional) | Whether to export all the events or  only messages. Default to `false`. 
+
+# Responses
+> 
+Name | Type | Description
+-----|------|------------
+_links | object | See [Response body Structure - Links](#links) 
+_links.self | string | URL of the response 
+id | string | Unique identifier of the response 
+
+A response is .
+
+## List Responses
+```shell
+
+curl --include \
+     --header "Authorization: Bearer {your_token}" \
+     --header "Accept: application/json" \
+'https://api2.frontapp.com/responses'
+```
+
+```node
+
+```
+
+> Response **200**
+
+```json
+{
+  "_links": {
+    "self": "https://api2.frontapp.com/responses"
+  },
+  "_results": [
+    {
+      "_links": {
+        "self": "https://api2.frontapp.com/responses/rsp_42"
+      },
+      "id": "rsp_42"
+    }
+  ]
+}
+```
+Lists the responses in your company.
+
+### HTTP Request
+
+`GET https://api2.frontapp.com/responses`
+## Get response
+```shell
+
+curl --include \
+     --header "Authorization: Bearer {your_token}" \
+     --header "Accept: application/json" \
+'https://api2.frontapp.com/responses/${RESPONSE_ID}'
+```
+
+```node
+
+```
+
+> Response **200**
+
+```json
+{
+  "_links": {
+    "self": "https://api2.frontapp.com/responses/rsp_42"
+  },
+  "id": "rsp_42"
+}
+```
+Fetches the information of a response.
+
+### HTTP Request
+
+`GET https://api2.frontapp.com/responses/{response_id}`
+### Parameters
+
+
+Name | Type | Description
+-----|------|------------
+response_id | string | Id the requested response

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -267,7 +267,6 @@ curl --include \
   \"username\": \"bender\",
   \"first_name\": \"Bender\",
   \"last_name\": \"Rodriguez\",
-  \"is_admin\": true,
   \"is_available\": false
 }" \
 'https://api2.frontapp.com/teammates/${TEAMMATE_ID}'
@@ -299,7 +298,6 @@ Name | Type | Description
 username | string (optional) | New username. It must be unique and can only contains lowercase letters, numbers and underscores. 
 first_name | string (optional) | New first name 
 last_name | string (optional) | New last name 
-is_admin | boolean (optional) | New admin status 
 is_available | boolean (optional) | New availability status 
 
 ## List teammate conversations
@@ -4056,7 +4054,7 @@ tag_id | string | ID of the requested tag
 Name | Type | Description
 -----|------|------------
 name | string (optional) | Name of the tag to create. 
-highlight | string (optional) | Color to highlight the tag with. . Set to `null` to remove highlighting. 
+highlight | string (optional) | Color to highlight the tag with. Set to `null` to remove highlighting. 
 
 ## Delete tag
 ```shell
@@ -5435,7 +5433,7 @@ attachments | array (optional) | List of files attached to the response
 created_at | number (optional) | Timestamp of response creation 
 updated_at | number (optional) | Timestamp of the last update 
 
-A response is predetermined answer to common questions. They allow you to respond faster to inbound messages, and lessen the repetitive nature of replying to frequently asked questions.
+Responses are predetermined answer to common questions. They allow you to respond faster to inbound messages, and lessen the repetitive nature of replying to frequently asked questions.
 
 Front allows individual and team canned responses. Individual canned responses are visible to only you, and team canned responses can be visible to your teammates on a per inbox level.
 
@@ -5532,7 +5530,7 @@ curl --include \
   "updated_at": 0
 }
 ```
-Fetches the information of a response.
+Fetches the information of an individual response.
 
 ### HTTP Request
 


### PR DESCRIPTION
Customer asking for canned responses API, so add the documentation for it
https://front.frontapp.com/open/cnv_1cxiawz

Blurb taken from https://help.frontapp.com/t/63244r/how-to-create-canned-responses

## Demo

![Screen Shot 2019-05-01 at 7 07 21 PM](https://user-images.githubusercontent.com/7429760/57053690-97b04b80-6c44-11e9-881c-5d33fa3e6a13.png)
![Screen Shot 2019-05-01 at 7 08 02 PM](https://user-images.githubusercontent.com/7429760/57053693-98e17880-6c44-11e9-86e2-6ca49951c16e.png)
