### PR TITLE
Rate Limiter Docs + Conv Assignee

### DIFF
--- a/source/api-blueprint/data_structures/conversation.apib
+++ b/source/api-blueprint/data_structures/conversation.apib
@@ -36,3 +36,8 @@
 + tag_ids (array[string], optional) - List of all the tag IDs replacing the old conversation tags
     + `tag_55c8c148`
     + `tag_55c8c149`
+
+
+## Conversation to put
+
++ assignee_id: `null` (string, required) - ID of the teammate to assign the conversation to. Set it to null to unassign.

--- a/source/api-blueprint/endpoints/conversations.apib
+++ b/source/api-blueprint/endpoints/conversations.apib
@@ -58,6 +58,18 @@ Updates a conversation. You can:
 
 + Response 204
 
+### Update conversation assignee [PUT /conversations/{conversation_id}/assignee]
+
+Updates a conversation's assignee.
+
+* Assign or unassign a conversation by sending an `assignee_id`
+
++ Request (application/json)
+    <!-- include(../includes/request_header.apib) -->
+    + Attributes (Conversation to put)
+
++ Response 204
+
 ### List conversation inboxes [GET /conversations/{conversation_id}/inboxes]
 
 Lists the inboxes in which a conversation appears.

--- a/source/changelog.html.md
+++ b/source/changelog.html.md
@@ -12,6 +12,11 @@ toc_footers:
 
 The changelog is the history of updates released. Front is committed in not breaking backwards compatibility between releases.
 
+## 2019-05-24 - Rate Limiter Updates
+
+### Changed
+* Additional rate limiting on resource intensive routes to better protect Front's infrastructure. Please see 'Rate Limiting' for more details.
+
 ## 2019-05-10 - Tag & Conversation endpoints updates
 
 ### Added

--- a/source/changelog.html.md
+++ b/source/changelog.html.md
@@ -17,7 +17,7 @@ The changelog is the history of updates released. Front is committed in not brea
 ### Changed
 * Additional rate limiting on resource intensive routes to better protect Front's infrastructure. Please see 'Rate Limiting' for more details.
 
-## 2019-06-03 - Conversation endpoints updates
+## 2019-05-20 - Conversation endpoints updates
 
 ### Added
 * `PUT /conversations/:conversation_id/assignee` route to update the assignee of the provided conversation. 

--- a/source/changelog.html.md
+++ b/source/changelog.html.md
@@ -17,6 +17,11 @@ The changelog is the history of updates released. Front is committed in not brea
 ### Changed
 * Additional rate limiting on resource intensive routes to better protect Front's infrastructure. Please see 'Rate Limiting' for more details.
 
+## 2019-05-24 - Conversation endpoints updates
+
+### Added
+* `PUT /conversations/:conversation_id/assignee` route to update the assignee of the provided conversation. 
+
 ## 2019-05-10 - Tag & Conversation endpoints updates
 
 ### Added

--- a/source/changelog.html.md
+++ b/source/changelog.html.md
@@ -12,12 +12,12 @@ toc_footers:
 
 The changelog is the history of updates released. Front is committed in not breaking backwards compatibility between releases.
 
-## 2019-05-24 - Rate Limiter Updates
+## 2019-06-03 - Rate Limiter Updates
 
 ### Changed
 * Additional rate limiting on resource intensive routes to better protect Front's infrastructure. Please see 'Rate Limiting' for more details.
 
-## 2019-05-24 - Conversation endpoints updates
+## 2019-06-03 - Conversation endpoints updates
 
 ### Added
 * `PUT /conversations/:conversation_id/assignee` route to update the assignee of the provided conversation. 

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -1514,6 +1514,47 @@ inbox_id: `inb_128yew` | string (optional) | ID of the inbox to move the convers
 status | enum (optional) | New status of the conversation 
 tag_ids | array (optional) | List of all the tag IDs replacing the old conversation tags 
 
+## Update conversation assignee
+```shell
+
+curl --include \
+     --request PUT \
+     --header "Content-Type: application/json" \
+     --header "Authorization: Bearer {your_token}" \
+     --header "Accept: application/json" \
+     --data-binary "{
+  \"assignee_id\": \"null\"
+}" \
+'https://api2.frontapp.com/conversations/${CONVERSATION_ID}/assignee'
+```
+
+```node
+
+```
+
+> Response **204**
+
+Updates a conversation's assignee.
+
+* Assign or unassign a conversation by sending an `assignee_id`
+
+### HTTP Request
+
+`PUT https://api2.frontapp.com/conversations/{conversation_id}/assignee`
+### Parameters
+
+
+Name | Type | Description
+-----|------|------------
+conversation_id | string | Id of the requested conversation
+
+### Body
+
+
+Name | Type | Description
+-----|------|------------
+assignee_id | string | ID of the teammate to assign the conversation to. Set it to null to unassign. 
+
 ## List conversation inboxes
 ```shell
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -88,9 +88,13 @@ Retry-After: 20
 When the rate limit is exceeded, the server will respond with a [**429 Too Many Requests**](https://tools.ietf.org/html/rfc6585#section-4) HTTP code with the header `Retry-After` to tell you how many seconds you need to wait before you can retry the request.
 
 ### Additional Rate limiting
-Some resource intensive routes are subject to additional rate limiting to prevent strain on Front's infrastructure. Such routes have the header `X-Front-Tier`. If you are rate limited for such a route, you will receive the header `Retry-After`, even though `X-RateLimit-Remaining` may be greater than 0. 
+Some resource intensive routes are subject to additional rate limiting to prevent strain on Front's infrastructure. This additional rate limit has a short TTL and only prevents sudden bursts of requests. The limit will depend on the resources needed to fulfill the request.
+
+Such routes have the header `X-Front-Tier`. If you are rate limited for such a route, you will receive the header `Retry-After`, even though `X-RateLimit-Remaining` may be greater than 0. This is because the limits do not affect each other.
 
 Please wait `Retry-After` seconds before safely retrying the request.
+
+If you experience any difficulties, please <a href='mailto:api@frontapp.com'>contact us</a>.
 
 ### Individual resources
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -65,14 +65,14 @@ Some endpoints also support multipart requests for file upload. For more details
 
 ### Rate limiting
 
-By default, the API is limited to 120 requests in 60 seconds. If you need more, just ask us and we will consider raising your quota.
+By default, the API is limited to 100 requests in 60 seconds. If you need more, please <a href='mailto:api@frontapp.com'>contact us</a>.
 Every response will contains three headers related to the rate-limiting:
 
 > Example of a response to a request exceeding the rate limit. The client should wait 20s before resending the request.
 
 ```http
 HTTP/1.1 429 Too Many Requests
-X-RateLimit-Limit: 120
+X-RateLimit-Limit: 100
 X-RateLimit-Remaining: 0
 X-RateLimit-Reset: 1454450858
 Retry-After: 20
@@ -86,6 +86,11 @@ Retry-After: 20
 
 
 When the rate limit is exceeded, the server will respond with a [**429 Too Many Requests**](https://tools.ietf.org/html/rfc6585#section-4) HTTP code with the header `Retry-After` to tell you how many seconds you need to wait before you can retry the request.
+
+### Additional Rate limiting
+Some resource intensive routes are subject to additional rate limiting to prevent strain on Front's infrastructure. Such routes have the header `X-Front-Tier`. If you are rate limited for such a route, you will receive the header `Retry-After`, even though `X-RateLimit-Remaining` may be greater than 0. 
+
+Please wait `Retry-After` seconds before safely retrying the request.
 
 ### Individual resources
 


### PR DESCRIPTION
Update docs for rate limiter + new PUT conversation assignee route
<img width="1691" alt="Screen Shot 2019-05-23 at 6 57 40 PM" src="https://user-images.githubusercontent.com/7429760/58297532-e0af7780-7d8c-11e9-9340-cd66b646425d.png">
<img width="1075" alt="Screen Shot 2019-05-23 at 6 42 20 PM" src="https://user-images.githubusercontent.com/7429760/58297533-e0af7780-7d8c-11e9-86bd-6274566f6f5b.png">

"Additional Rate Limiting"
<img width="1073" alt="Screen Shot 2019-05-23 at 6 36 49 PM" src="https://user-images.githubusercontent.com/7429760/58297534-e1480e00-7d8c-11e9-9faf-17dd6a40f632.png">
