### PR TITLE
List Teammate custom contact field

### DIFF
--- a/source/api-blueprint/endpoints/custom_fields.apib
+++ b/source/api-blueprint/endpoints/custom_fields.apib
@@ -4,12 +4,13 @@ A custom field defines the name and type for an extra field of a contact. Only l
 
 Each custom field has a specified data type. Ensure the data you submit when updating a custom field's value is formatted correctly:
 
-| Type     | Example        | Description               |
-|----------|----------------|---------------------------|
-| String   | `"London, UK"` | String values             |
-| Boolean  | `true`         | Boolean true/false values |
-| Number   | `90`           | Integers                  |
-| Datetime | `1525417200`   | Epoch timestamp           |
+| Type     | Example                    | Description                 |
+|----------|----------------------------|-----------------------------|
+| String   | `"London, UK"`             | String values               |
+| Boolean  | `true`                     | Boolean true/false values   |
+| Number   | `90`                       | Integers                    |
+| Datetime | `1525417200`               | Epoch timestamp             |
+| Teammate | `leela@planet-express.com` | Email address of a teammate |
 
 ### List custom fields [GET /custom_fields]
 

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -2408,12 +2408,13 @@ A custom field defines the name and type for an extra field of a contact. Only l
 
 Each custom field has a specified data type. Ensure the data you submit when updating a custom field's value is formatted correctly:
 
-| Type     | Example        | Description               |
-|----------|----------------|---------------------------|
-| String   | `"London, UK"` | String values             |
-| Boolean  | `true`         | Boolean true/false values |
-| Number   | `90`           | Integers                  |
-| Datetime | `1525417200`   | Epoch timestamp           |
+| Type     | Example                    | Description                 |
+|----------|----------------------------|-----------------------------|
+| String   | `"London, UK"`             | String values               |
+| Boolean  | `true`                     | Boolean true/false values   |
+| Number   | `90`                       | Integers                    |
+| Datetime | `1525417200`               | Epoch timestamp             |
+| Teammate | `leela@planet-express.com` | Email address of a teammate |
 
 ## List custom fields
 ```shell


### PR DESCRIPTION
Adds the `teammate` custom contact field type to https://dev.frontapp.com/#custom-fields

<img width="685" alt="Screen Shot 2019-10-07 at 16 06 09" src="https://user-images.githubusercontent.com/273718/66355604-b5cd5680-e91c-11e9-8713-6fe1e4bdc674.png">
