### PR TITLE
Add SMTP channel creation documentation

### DIFF
--- a/source/api-blueprint/data_structures/channel.apib
+++ b/source/api-blueprint/data_structures/channel.apib
@@ -24,7 +24,7 @@
 
 ## Channel settings
 
-+ settings (object, optional) - Required only for `custom` channels.
++ settings (object, optional) - **Required only for `custom` channels.**
   + webhook_url: `http://example.com` (string, optional) - `custom` type only. URL to which will be sent the replies of a custom message.
   + reply_mode: `unsupported` (enum, optional) - How the channel can be used to reply to a message.
   + compose_mode: `normal` (enum, optional) - Grants ability to compose new messages from this channel (`normal`) or prevents composing new messages (`unsupported`). Can be one of: `normal` or `unsupported`. (Default: `unsupported`)
@@ -33,11 +33,11 @@
 ## Channel to create
 
 + name: `My channel` (string, optional) - Name of the channel.
-+ type (enum[string], required) - Type of the channel.
++ type (enum[string], required) - Type of the channel. Can be one of: `custom`, `smtp`.
     + Members
         + `custom`
         + `smtp`
-+ send_as (string, optional) - Required for only for `smtp` channels. Address of your SMTP mailbox.
++ send_as (string, optional) - **Required only for `smtp` channels**. Address of your SMTP mailbox.
 
 + Include Channel settings
 

--- a/source/api-blueprint/data_structures/channel.apib
+++ b/source/api-blueprint/data_structures/channel.apib
@@ -24,7 +24,7 @@
 
 ## Channel settings
 
-+ settings (object, required)
++ settings (object, optional) - Required only for `custom` channels.
   + webhook_url: `http://example.com` (string, optional) - `custom` type only. URL to which will be sent the replies of a custom message.
   + reply_mode: `unsupported` (enum, optional) - How the channel can be used to reply to a message.
   + compose_mode: `normal` (enum, optional) - Grants ability to compose new messages from this channel (`normal`) or prevents composing new messages (`unsupported`). Can be one of: `normal` or `unsupported`. (Default: `unsupported`)
@@ -36,13 +36,16 @@
 + type (enum[string], required) - Type of the channel.
     + Members
         + `custom`
+        + `smtp`
++ send_as (string, optional) - Required for only for `smtp` channels. Address of your SMTP mailbox.
+
 + Include Channel settings
 
 ## Channel created
 
 + id: `cha_55c8c149` (string, required) - Unique identifier for the channel.
 + Include Channel to create
-+ address: `dw0a0b7aeg36cb56` - Address receiving the messages.
++ address: `dw0a0b7aeg36cb56` - Address receiving the messages. Is the forwarding address for SMTP channels.
 + sendAs: `dw0a0b7aeg36cb56` - Address which appears as the sender for messages sent from Front.
 + Include Channel settings
 

--- a/source/api-blueprint/endpoints/channels.apib
+++ b/source/api-blueprint/endpoints/channels.apib
@@ -73,7 +73,8 @@ As of today, you can create either a <a href="#custom-channels">custom channel</
 </aside>
 
 For `smtp` type channels, we will create an unvalidated SMTP channel.
-* In the response body, `address` is the **forwarding address**. To complete the SMTP validation process, [add the forwarding address to your email provider's settings](https://help.frontapp.com/t/632v5z/switch-from-gmailo365-to-smtp-forwarding).
+* In the response body returned, `address` is the **forwarding address**. 
+* To complete the SMTP validation process, [add the forwarding address to your email provider's settings](https://help.frontapp.com/t/632v5z/switch-from-gmailo365-to-smtp-forwarding).
 
 For `custom` type channels:
 * `reply_mode` can be one of: `same_channel` (channel can only reply to messages within the same channel) or `unsupported` (channel cannot reply to any messages) (Default: `same_channel`)

--- a/source/api-blueprint/endpoints/channels.apib
+++ b/source/api-blueprint/endpoints/channels.apib
@@ -69,10 +69,14 @@ As of today, you can only update the settings of a <a href="#custom-channels">cu
 Creates a channel linked to the requested inbox.
 
 <aside class="notice">
-As of today, you can only create a <a href="#custom-channels">custom channel</a> with the API.
+As of today, you can create either a <a href="#custom-channels">custom channel</a> or a SMTP channel with the API.
 </aside>
 
-`reply_mode` can be one of: `same_channel` (channel can only reply to messages within the same channel) or `unsupported` (channel cannot reply to any messages) (Default: `same_channel`)
+For `smtp` type channels, we will create an unvalidated SMTP channel.
+* In the response body, `address` is the **forwarding address**. To complete the SMTP validation process, [add the forwarding address to your email provider's settings](https://help.frontapp.com/t/632v5z/switch-from-gmailo365-to-smtp-forwarding).
+
+For `custom` type channels:
+* `reply_mode` can be one of: `same_channel` (channel can only reply to messages within the same channel) or `unsupported` (channel cannot reply to any messages) (Default: `same_channel`)
 
 + Parameters
     + inbox_id (string, required) - Id of the inbox into which the channel messages will go.

--- a/source/api-blueprint/endpoints/channels.apib
+++ b/source/api-blueprint/endpoints/channels.apib
@@ -72,7 +72,7 @@ Creates a channel linked to the requested inbox.
 As of today, you can create either a <a href="#custom-channels">custom channel</a> or a SMTP channel with the API.
 </aside>
 
-For `smtp` type channels, we will create an unvalidated SMTP channel.
+For `smtp` type channels, we will create an **unvalidated** SMTP channel.
 * In the response body returned, `address` is the **forwarding address**. 
 * To complete the SMTP validation process, [add the forwarding address to your email provider's settings](https://help.frontapp.com/t/632v5z/switch-from-gmailo365-to-smtp-forwarding).
 

--- a/source/changelog.html.md
+++ b/source/changelog.html.md
@@ -12,6 +12,11 @@ toc_footers:
 
 The changelog is the history of updates released. Front is committed in not breaking backwards compatibility between releases.
 
+## 2019-10-29 - Create SMTP channel.
+
+### Changed
+* Added the ability to create an unvalidated SMTP channel via `POST /inboxes/{inbox_id}/channels`
+
 ## 2019-09-17 - Resource IDs in custom plugin API.
 
 ### Changed

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -1267,10 +1267,16 @@ curl --include \
 Creates a channel linked to the requested inbox.
 
 <aside class="notice">
-As of today, you can only create a <a href="#custom-channels">custom channel</a> with the API.
+As of today, you can create either a <a href="#custom-channels">custom channel</a> or a SMTP channel with the API.
 </aside>
 
-`reply_mode` can be one of: `same_channel` (channel can only reply to messages within the same channel) or `unsupported` (channel cannot reply to any messages) (Default: `same_channel`)
+For `smtp` type channels, we will create an unvalidated SMTP channel.
+
+* In the response body, `address` is the **forwarding address**. To complete the SMTP validation process, [add the forwarding address to your email provider's settings](https://help.frontapp.com/t/632v5z/switch-from-gmailo365-to-smtp-forwarding).
+
+For `custom` type channels:
+
+* `reply_mode` can be one of: `same_channel` (channel can only reply to messages within the same channel) or `unsupported` (channel cannot reply to any messages) (Default: `same_channel`)
 
 ### HTTP Request
 
@@ -1289,7 +1295,8 @@ Name | Type | Description
 -----|------|------------
 name | string (optional) | Name of the channel. 
 type | enum | Type of the channel. 
-settings | object |  
+send_as | string (optional) | Required for only for `smtp` channels. Address of your SMTP mailbox. 
+settings | object (optional) | Required only for `custom` channels. 
 settings.webhook_url | string (optional) | `custom` type only. URL to which will be sent the replies of a custom message. 
 settings.reply_mode | enum (optional) | How the channel can be used to reply to a message. 
 settings.compose_mode | enum (optional) | Grants ability to compose new messages from this channel (`normal`) or prevents composing new messages (`unsupported`). Can be one of: `normal` or `unsupported`. (Default: `unsupported`) 

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -1270,7 +1270,7 @@ Creates a channel linked to the requested inbox.
 As of today, you can create either a <a href="#custom-channels">custom channel</a> or a SMTP channel with the API.
 </aside>
 
-For `smtp` type channels, we will create an unvalidated SMTP channel.
+For `smtp` type channels, we will create an **unvalidated** SMTP channel.
 
 * In the response body returned, `address` is the **forwarding address**.
 

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -1272,7 +1272,9 @@ As of today, you can create either a <a href="#custom-channels">custom channel</
 
 For `smtp` type channels, we will create an unvalidated SMTP channel.
 
-* In the response body, `address` is the **forwarding address**. To complete the SMTP validation process, [add the forwarding address to your email provider's settings](https://help.frontapp.com/t/632v5z/switch-from-gmailo365-to-smtp-forwarding).
+* In the response body returned, `address` is the **forwarding address**.
+
+* To complete the SMTP validation process, [add the forwarding address to your email provider's settings](https://help.frontapp.com/t/632v5z/switch-from-gmailo365-to-smtp-forwarding).
 
 For `custom` type channels:
 
@@ -1294,9 +1296,9 @@ inbox_id | string | Id of the inbox into which the channel messages will go.
 Name | Type | Description
 -----|------|------------
 name | string (optional) | Name of the channel. 
-type | enum | Type of the channel. 
-send_as | string (optional) | Required for only for `smtp` channels. Address of your SMTP mailbox. 
-settings | object (optional) | Required only for `custom` channels. 
+type | enum | Type of the channel. Can be one of: `custom`, `smtp`. 
+send_as | string (optional) | **Required only for `smtp` channels**. Address of your SMTP mailbox. 
+settings | object (optional) | **Required only for `custom` channels.** 
 settings.webhook_url | string (optional) | `custom` type only. URL to which will be sent the replies of a custom message. 
 settings.reply_mode | enum (optional) | How the channel can be used to reply to a message. 
 settings.compose_mode | enum (optional) | Grants ability to compose new messages from this channel (`normal`) or prevents composing new messages (`unsupported`). Can be one of: `normal` or `unsupported`. (Default: `unsupported`) 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

My focus:
* Make it clear that different request body is expected depending on `type`.
* Make it clear the `address` is the forwarding address for SMTP channels.
![Screen Shot 2019-10-29 at 2 59 57 PM](https://user-images.githubusercontent.com/7429760/67812616-d6d92100-fa5c-11e9-821f-60054b2f014c.png)
