### PR TITLE
Deprecate tags in send message routes

### DIFF
--- a/source/api-blueprint/data_structures/message.apib
+++ b/source/api-blueprint/data_structures/message.apib
@@ -47,7 +47,7 @@
 + text: `Why is Zoidberg the only one still alone?` (string, optional) - Text version of the body for messages with non-text body
 + attachments (array[], optional) - Binary data of the attached files. Available only for [multipart request](#send-multipart-request).
 + options (object, optional) - Sending options
-    + tags (array[string], optional) - List of tag names to add to the conversation (unknown tags will automatically be created)
+    + tag_ids (array[string], optional) - List of tag IDs to add to the conversation
     + archive: `true` (boolean, optional) - Archive the conversation right when sending the message
         + Default: `true`
 

--- a/source/changelog.html.md
+++ b/source/changelog.html.md
@@ -18,10 +18,15 @@ toc_footers:
 
 The changelog is the history of updates released. Front is committed in not breaking backwards compatibility between releases.
 
+## 2020-01-10 - Send Message Updates
+
+### Deprecated
+* Deprecate `tag` from `POST /channels/{channel_id}/messages` and `POST /conversations/{conversation_id}/messages`. Please use `tag_ids` instead.
+
 ## 2019-11-12 - Channel API
 
 ### Added
-* Description of our channel API.
+* Description of our Channel API.
 * Receive messages in Front through `POST /channels/{channel_id}/inbound_messages` & `POST /channels/{channel_id}/outbound_messages`
 
 ### Deprecated

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -3265,7 +3265,7 @@ curl --include \
   \"text\": \"Why is Zoidberg the only one still alone?\",
   \"attachments\": [],
   \"options\": {
-    \"tags\": [],
+    \"tag_ids\": [],
     \"archive\": true
   },
   \"to\": [
@@ -3358,7 +3358,7 @@ body | string | Body of the message
 text | string (optional) | Text version of the body for messages with non-text body 
 attachments | array (optional) | Binary data of the attached files. Available only for [multipart request](#send-multipart-request). 
 options | object (optional) | Sending options 
-options.tags | array (optional) | List of tag names to add to the conversation (unknown tags will automatically be created) 
+options.tag_ids | array (optional) | List of tag IDs to add to the conversation 
 options.archive | boolean (optional) | Archive the conversation right when sending the message (Default: `true`)
 to | array | List of the recipient handles who will receive this message 
 cc | array (optional) | List of the recipient handles who will receive a copy of this message 
@@ -3380,7 +3380,7 @@ curl --include \
   \"text\": \"Why is Zoidberg the only one still alone?\",
   \"attachments\": [],
   \"options\": {
-    \"tags\": [],
+    \"tag_ids\": [],
     \"archive\": true
   },
   \"channel_id\": \"cha_55c8c149\",
@@ -3472,7 +3472,7 @@ body | string | Body of the message
 text | string (optional) | Text version of the body for messages with non-text body 
 attachments | array (optional) | Binary data of the attached files. Available only for [multipart request](#send-multipart-request). 
 options | object (optional) | Sending options 
-options.tags | array (optional) | List of tag names to add to the conversation (unknown tags will automatically be created) 
+options.tag_ids | array (optional) | List of tag IDs to add to the conversation 
 options.archive | boolean (optional) | Archive the conversation right when sending the message (Default: `true`)
 channel_id | string (optional) | Channel through which to send the message. Defaults to the original conversation channel. For imported messages or messages received on multiple channels, you **MUST** specify a channel ID. 
 to | array (optional) | List of the recipient handles who will receive this message. By default it will use the recipients of the last received message. 


### PR DESCRIPTION
We should no longer document that we accept tag names - moving forward we should only accept tag_ids.

For backwards compatibility we still accept tags