### PR TITLE
PB-17920 Restore custom channel docs

### DIFF
--- a/source/api-blueprint/data_structures/channel.apib
+++ b/source/api-blueprint/data_structures/channel.apib
@@ -22,13 +22,25 @@
 + settings (object, required)
 + is_private: `false` (boolean, required) - Whether or not the channel is individual
 
+
+## Channel settings
+
++ settings (object, optional) - **Required only for `custom` channels.**
+  + webhook_url: `http://example.com` (string, optional) - `custom` type only. URL to which will be sent the replies of a custom message.
+  + reply_mode: `unsupported` (enum, optional) - How the channel can be used to reply to a message.
+  + compose_mode: `normal` (enum, optional) - Grants ability to compose new messages from this channel (`normal`) or prevents composing new messages (`unsupported`). Can be one of: `normal` or `unsupported`. (Default: `unsupported`)
+  + contact_type: `email` (enum, optional) - Contact type the channel uses. It can only be set on channel creation. Can be one of: `custom`, `email` or `phone`. (Default: `custom`)
+
 ## Channel to create
 
 + name: `My channel` (string, optional) - Name of the channel.
-+ type (enum[string], required) - Type of the channel. Must be `smtp`.
++ type (enum[string], required) - Type of the channel. Can be one of: `custom`,  `smtp`.
     + Members
+        + `custom`
         + `smtp`
-+ send_as (string, optional) - Address of your SMTP mailbox.
++ send_as (string, optional) - **Required only for `smtp` channels**. Address of your SMTP mailbox.
+
++ Include Channel settings
 
 ## Channel created
 
@@ -65,3 +77,7 @@
 + type: `success` (string, required) - Did front accept the message
 + external_id: `external message 2` (string, required) - External message id for this message
 + external_conversation_id: `external_conversation_1` (string, required) - External conversation id for this message
+
+## Channel to update
++ name: `My channel` (string, optional) - Name of the channel.
++ settings (object, optional) - Settings to replace.

--- a/source/api-blueprint/data_structures/message.apib
+++ b/source/api-blueprint/data_structures/message.apib
@@ -67,6 +67,23 @@
 + cc (array[string], optional) - List of the recipient handles who will receive a copy of this message
 + bcc (array[string], optional) - List of the recipient handles who will receive a blind copy of this message
 
+
+## Custom message
+
++ sender (object, required) - Data of the sender
+    + contact_id (string, optional) - ID of the contact in Front corresponding to the sender
+    + name: `hermes` (string, optional) - Name of the sender
+    + handle: `hermes_123` (string, required) - Handle of the sender. It can be any string used to uniquely identify the sender
++ subject: `Question` (string, optional) - Subject of the message
++ body: `Didn't we used to be a delivery company?` (string, required) - Body of the message
++ body_format: `markdown` (enum[string], optional, default) - Format of the message body.
+     + `html`
+     + `markdown`
++ attachments (array[], optional) - Binary data of the attached files. Available only for [multipart request](#send-multipart-request).
++ metadata (object, optional)
+    + thread_ref (string, optional) - Custom reference which will be used to thread messages. If you omit this field, we'll thread by sender instead
+    + headers (object, optional) - Custom object where any internal information can be stored
+
 ## Outbound reply
 
 + Include Outbound message

--- a/source/api-blueprint/endpoints/channels.apib
+++ b/source/api-blueprint/endpoints/channels.apib
@@ -16,7 +16,7 @@ Here is the list of existing channel types:
 | `smooch`    | Linked to a Smooch account.                                                                |
 | `intercom`  | Linked to an Intercom account.                                                             |
 | `truly`     | Linked to a truly account.                                                                 |
-| `custom`    | For messages sent and received only through the API (cf [Custom inboxes](/channels-api.html)).|
+| `custom`    | For messages sent and received only through the API.|
 
 + Parameters
     + channel_id (string, required) - Id of the requested channel
@@ -50,12 +50,12 @@ Fetches the information of a channel. See [resource aliases](#resource-aliases) 
 + Response 200 (application/json)
     + Attributes (Channel)
 
-### Create an SMTP channel [POST /inboxes/{inbox_id}/channels]
+### Create a channel [POST /inboxes/{inbox_id}/channels]
 
-Creates an SMTP channel linked to the requested inbox.
+Creates a channel linked to the requested inbox.
 
 <aside class="notice">
-As of today, you can only create an SMTP channel with the API.
+As of today, you can only create an SMTP or custom channel with the API.
 </aside>
 
 For `smtp` type channels, we will create an **unvalidated** SMTP channel.
@@ -72,10 +72,30 @@ For `smtp` type channels, we will create an **unvalidated** SMTP channel.
 + Response 201 (application/json)
     + Attributes (Channel created)
 
+### Update a channel [PATCH]
+
+Updates the settings of a channel.
+
+<aside class="notice">
+As of today, you can only update the settings of a custom channel with the API.
+</aside>
+
+`reply_mode` can be one of: `same_channel` (channel can only reply to messages within the same channel) or `unsupported` (channel cannot reply to any messages) (Default: `same_channel`)
+
++ Request (application/json)
+    <!-- include(../includes/request_header.apib) -->
+    + Attributes (Channel to update)
+
++ Response 204
+
 ### Receive Message [POST /channels/{channel_id}/inbound_messages]
 
 <aside class="warning">
-This endpoint can only be used by Channels in partnership with Front. See the <a href="/channels-api.html">Channels API offering</a> for more info. 
+This endpoint can only be used by Channels in partnership with Front. See the <a href="/channels-api.html">Channels API offering</a> for more info.
+</aside>
+
+<aside class="notice">
+If you are building a channel to be used for your company only, please use the <a href="/#receive-custom-message">incoming message </a> endpoint.
 </aside>
 
 When your system receives a message, this message can be sent to the Front channel by posting it to this endpoint.

--- a/source/api-blueprint/endpoints/messages.apib
+++ b/source/api-blueprint/endpoints/messages.apib
@@ -81,6 +81,29 @@ If you want to send a reply with attached files, please check [how to send multi
 <!-- include(../includes/accepted_response.apib) -->
     + Attributes (Draft)
 
+### Receive custom message [POST /channels/{channel_id}/incoming_messages]
+
+Receives a custom message in Front. This endpoint is available for custom channels **ONLY**.
+
+If you want to receive a custom message with attached files, please check [how to send multipart request](#send-multipart-request).
+
+<aside class="notice">
+Receiving a message in Front is done asynchronously. <br>
+The endpoint will only validate the payload and will return a <code>message_uid</code> that can be used as an alias for the message ID (<code>alt:uid:{message_uid}</code>.
+<br><br>
+We guarantee that the UID will refer to a message but we don't guarantee that the message already exists. The API might respond with a 404 error code if trying to use the UID before the message is effectively created.
+</aside>
+
++ Parameters
+    + channel_id (string, required) - Id of the requested custom channel
+
++ Request (application/json)
+    <!-- include(../includes/request_header.apib) -->
+    + Attributes (Custom message)
+
+<!-- include(../includes/accepted_response.apib) -->
+    + Attributes (Accepted message)
+
 ### Import message [POST /inboxes/{inbox_id}/imported_messages]
 
 Appends a new message into an inbox.

--- a/source/changelog.html.md
+++ b/source/changelog.html.md
@@ -18,6 +18,13 @@ toc_footers:
 
 The changelog is the history of updates released. Front is committed in not breaking backwards compatibility between releases.
 
+## 2020-01-23 - Documentation Updates
+
+### Restored documentation for
+* Creating a custom channel through `POST /channels` with the body `{type: 'custom'}`.
+* Updating a custom channel through `PATCH /channels/{channel_id}`.
+* Receive a custom message through `POST /channels/{channel_id}/incoming_messages`.
+
 ## 2020-01-10 - Send Message Updates
 
 ### Deprecated

--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -1084,7 +1084,7 @@ Here is the list of existing channel types:
 | `smooch`    | Linked to a Smooch account.                                                                |
 | `intercom`  | Linked to an Intercom account.                                                             |
 | `truly`     | Linked to a truly account.                                                                 |
-| `custom`    | For messages sent and received only through the API (cf [Custom inboxes](/channels-api.html)).|
+| `custom`    | For messages sent and received only through the API.|
 
 ## List channels
 ```shell
@@ -1178,7 +1178,7 @@ Name | Type | Description
 -----|------|------------
 channel_id | string | Id of the requested channel
 
-## Create an SMTP channel
+## Create a channel
 ```shell
 
 curl --include \
@@ -1188,7 +1188,13 @@ curl --include \
      --header "Accept: application/json" \
      --data-binary "{
   \"name\": \"My channel\",
-  \"type\": \"smtp\"
+  \"type\": \"custom\",
+  \"settings\": {
+    \"webhook_url\": \"http://example.com\",
+    \"reply_mode\": \"unsupported\",
+    \"compose_mode\": \"normal\",
+    \"contact_type\": \"email\"
+  }
 }" \
 'https://api2.frontapp.com/inboxes/${INBOX_ID}/channels'
 ```
@@ -1203,15 +1209,21 @@ curl --include \
 {
   "id": "cha_55c8c149",
   "name": "My channel",
-  "type": "smtp",
+  "type": "custom",
+  "settings": {
+    "webhook_url": "http://example.com",
+    "reply_mode": "unsupported",
+    "compose_mode": "normal",
+    "contact_type": "email"
+  },
   "address": "dw0a0-mowow@frontapp.com",
   "sendAs": "dw0a0-mowow@frontapp.com"
 }
 ```
-Creates an SMTP channel linked to the requested inbox.
+Creates a channel linked to the requested inbox.
 
 <aside class="notice">
-As of today, you can only create an SMTP channel with the API.
+As of today, you can only create an SMTP or custom channel with the API.
 </aside>
 
 For `smtp` type channels, we will create an **unvalidated** SMTP channel.
@@ -1236,8 +1248,59 @@ inbox_id | string | Id of the inbox into which the channel messages will go.
 Name | Type | Description
 -----|------|------------
 name | string (optional) | Name of the channel. 
-type | enum | Type of the channel. Must be `smtp`. 
-send_as | string (optional) | Address of your SMTP mailbox. 
+type | enum | Type of the channel. Can be one of: `custom`,  `smtp`. 
+send_as | string (optional) | **Required only for `smtp` channels**. Address of your SMTP mailbox. 
+settings | object (optional) | **Required only for `custom` channels.** 
+settings.webhook_url | string (optional) | `custom` type only. URL to which will be sent the replies of a custom message. 
+settings.reply_mode | enum (optional) | How the channel can be used to reply to a message. 
+settings.compose_mode | enum (optional) | Grants ability to compose new messages from this channel (`normal`) or prevents composing new messages (`unsupported`). Can be one of: `normal` or `unsupported`. (Default: `unsupported`) 
+settings.contact_type | enum (optional) | Contact type the channel uses. It can only be set on channel creation. Can be one of: `custom`, `email` or `phone`. (Default: `custom`) 
+
+## Update a channel
+```shell
+
+curl --include \
+     --request PATCH \
+     --header "Content-Type: application/json" \
+     --header "Authorization: Bearer {your_token}" \
+     --header "Accept: application/json" \
+     --data-binary "{
+  \"name\": \"My channel\"
+}" \
+'https://api2.frontapp.com/channels/${CHANNEL_ID}'
+```
+
+```node
+
+```
+
+> Response **204**
+
+Updates the settings of a channel.
+
+<aside class="notice">
+As of today, you can only update the settings of a custom channel with the API.
+</aside>
+
+`reply_mode` can be one of: `same_channel` (channel can only reply to messages within the same channel) or `unsupported` (channel cannot reply to any messages) (Default: `same_channel`)
+
+### HTTP Request
+
+`PATCH https://api2.frontapp.com/channels/{channel_id}`
+### Parameters
+
+
+Name | Type | Description
+-----|------|------------
+channel_id | string | Id of the requested channel
+
+### Body
+
+
+Name | Type | Description
+-----|------|------------
+name | string (optional) | Name of the channel. 
+settings | object (optional) | Settings to replace. 
 
 ## Receive Message
 ```shell
@@ -1275,7 +1338,11 @@ curl --include \
 }
 ```
 <aside class="warning">
-This endpoint can only be used by Channels in partnership with Front. See the <a href="/channels-api.html">Channels API offering</a> for more info. 
+This endpoint can only be used by Channels in partnership with Front. See the <a href="/channels-api.html">Channels API offering</a> for more info.
+</aside>
+
+<aside class="notice">
+If you are building a channel to be used for your company only, please use the <a href="/#receive-custom-message">incoming message </a> endpoint.
 </aside>
 
 When your system receives a message, this message can be sent to the Front channel by posting it to this endpoint.
@@ -3478,6 +3545,76 @@ channel_id | string (optional) | Channel through which to send the message. Defa
 to | array (optional) | List of the recipient handles who will receive this message. By default it will use the recipients of the last received message. 
 cc | array (optional) | List of the recipient handles who will receive a copy of this message. By default it will use the cc'ed recipients of the last received message. 
 bcc | array (optional) | List of the recipient handles who will receive a blind copy of this message 
+
+## Receive custom message
+```shell
+
+curl --include \
+     --request POST \
+     --header "Content-Type: application/json" \
+     --header "Authorization: Bearer {your_token}" \
+     --header "Accept: application/json" \
+     --data-binary "{
+  \"sender\": {
+    \"name\": \"hermes\",
+    \"handle\": \"hermes_123\"
+  },
+  \"subject\": \"Question\",
+  \"body\": \"Didn't we used to be a delivery company?\",
+  \"attachments\": [],
+  \"metadata\": {}
+}" \
+'https://api2.frontapp.com/channels/${CHANNEL_ID}/incoming_messages'
+```
+
+```node
+
+```
+
+> Response **202**
+
+```json
+{
+  "message_uid": "3b1q41d8"
+}
+```
+Receives a custom message in Front. This endpoint is available for custom channels **ONLY**.
+
+If you want to receive a custom message with attached files, please check [how to send multipart request](#send-multipart-request).
+
+<aside class="notice">
+Receiving a message in Front is done asynchronously. <br>
+The endpoint will only validate the payload and will return a <code>message_uid</code> that can be used as an alias for the message ID (<code>alt:uid:{message_uid}</code>.
+<br><br>
+We guarantee that the UID will refer to a message but we don't guarantee that the message already exists. The API might respond with a 404 error code if trying to use the UID before the message is effectively created.
+</aside>
+
+### HTTP Request
+
+`POST https://api2.frontapp.com/channels/{channel_id}/incoming_messages`
+### Parameters
+
+
+Name | Type | Description
+-----|------|------------
+channel_id | string | Id of the requested custom channel
+
+### Body
+
+
+Name | Type | Description
+-----|------|------------
+sender | object | Data of the sender 
+sender.contact_id | string (optional) | ID of the contact in Front corresponding to the sender 
+sender.name | string (optional) | Name of the sender 
+sender.handle | string | Handle of the sender. It can be any string used to uniquely identify the sender 
+subject | string (optional) | Subject of the message 
+body | string | Body of the message 
+body_format | enum (optional) | Format of the message body. Can be one of: `'html'`, `'markdown'`. (Default: `'markdown'`)
+attachments | array (optional) | Binary data of the attached files. Available only for [multipart request](#send-multipart-request). 
+metadata | object (optional) |  
+metadata.thread_ref | string (optional) | Custom reference which will be used to thread messages. If you omit this field, we'll thread by sender instead 
+metadata.headers | object (optional) | Custom object where any internal information can be stored 
 
 ## Import message
 ```shell


### PR DESCRIPTION
Restores the custom channel docs removed in
https://github.com/frontapp/api-documentation/pull/68
as we attempted to deprecate the endpoints too quickly.

Screenshots:
<img width="1920" alt="Screen Shot 2020-01-22 at 3 40 48 PM" src="https://user-images.githubusercontent.com/7429760/72944582-26627c80-3d2e-11ea-92fb-46495ece17fa.png">
<img width="1920" alt="Screen Shot 2020-01-22 at 3 40 52 PM" src="https://user-images.githubusercontent.com/7429760/72944585-282c4000-3d2e-11ea-87bc-1363b85a813b.png">
<img width="1920" alt="Screen Shot 2020-01-22 at 3 41 00 PM" src="https://user-images.githubusercontent.com/7429760/72944586-295d6d00-3d2e-11ea-876e-a43240de3bc1.png">
<img width="1123" alt="Screen Shot 2020-01-22 at 3 43 18 PM" src="https://user-images.githubusercontent.com/7429760/72944590-2bbfc700-3d2e-11ea-9071-01160d513156.png">
